### PR TITLE
feat(restaurant): add mean rating display with Vuetify, format phone …

### DIFF
--- a/src/components/restaurant/card.vue
+++ b/src/components/restaurant/card.vue
@@ -36,7 +36,7 @@ const { average, formatted, count } = useRestaurantRating(props.restaurant)
           {{ formatted }}
         </span>
         <span class="text-sm text-gray-500 ml-2">
-          ({{ count }} avis)
+          ({{ count }} reviews)
         </span>
       </div>
     </div>

--- a/src/components/restaurant/review.vue
+++ b/src/components/restaurant/review.vue
@@ -1,13 +1,28 @@
+<script setup lang="ts">
+import { type Review } from '~/composables/restaurants'
+
+defineProps<{
+  review: Review
+}>()
+</script>
+
 <template>
-  <VCard class="va-company-review" tag="li">
+  <VCard class="va-company-review mb-5" tag="li">
     <VCardText>
-      <VAlert type="warning">
-        TODO: implement the reviews
-        <br>
-        • Rating using the appropriate Vuetify component
-        <br>
-        • Text (with carriage return)
-      </VAlert>
+      <!-- Rating -->
+      <VRating
+        :model-value="review.rating"
+        readonly
+        half-increments
+        color="amber"
+        size="20"
+        class="mb-2"
+      />
+
+      <!-- Review text -->
+      <p class="text-gray-700 whitespace-pre-line">
+        {{ review.text }}
+      </p>
     </VCardText>
   </VCard>
 </template>

--- a/src/composables/restaurants.ts
+++ b/src/composables/restaurants.ts
@@ -38,7 +38,7 @@ export function useFetchRestaurant({ restaurantId }: { restaurantId: string | st
   return useQuery({
     queryKey: [`company`, restaurantId],
     queryFn: () => {
-      const url = `restorants/${restaurantId}`;
+      const url = `restaurants/${restaurantId}`;
       return api(url).json<Restaurant>();
     },
   });

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -12,7 +12,7 @@ const { data: restaurants, isError } = useFetchRestaurants();
 
     <div
       v-else-if="restaurants"
-      class="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+      class="grid gap-8 lg:gap-12 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
     >
       <RestaurantCard
         v-for="restaurant of restaurants"

--- a/src/pages/restaurants/[restaurantId].vue
+++ b/src/pages/restaurants/[restaurantId].vue
@@ -1,17 +1,22 @@
 <script setup lang="ts">
-import { useFetchRestaurant } from '~/composables/restaurants';
+import { useFetchRestaurant } from '~/composables/restaurants'
+import { useRestaurantRating } from '~/composables/useRestaurantRating'
 
-const { params } = useRoute();
-const { data: restaurant, isError } = useFetchRestaurant({ restaurantId: params.restaurantId });
+const { params } = useRoute()
+const { data: restaurant, isError } = useFetchRestaurant({ restaurantId: params.restaurantId })
+
+// rating (null tant que restaurant n’est pas encore chargé)
+const rating = computed(() =>
+  restaurant.value ? useRestaurantRating(restaurant.value) : null
+)
 </script>
 
 <template>
-  <VAlert v-if="isError" type="warning" class="mt-4">
-    TODO: It might be an Fetch error
-    <br>
-    You should fix that
+  <VAlert v-if="isError" type="error" class="mt-4">
+    Une erreur est survenue lors du chargement du restaurant.
+    Vérifie ta connexion ou réessaie plus tard.
   </VAlert>
-  <div v-else class="grid grid-cols-[minmax(0,_1fr)_16rem] gap-6">
+  <div v-else class="grid grid-cols-1 lg:grid-cols-[minmax(0,_1fr)_16rem] gap-6">
     <VCard v-if="restaurant">
       <VImg
         v-for="photo in restaurant.photos"
@@ -24,32 +29,43 @@ const { data: restaurant, isError } = useFetchRestaurant({ restaurantId: params.
         <VCardTitle class="!text-4xl text-white">
           {{ restaurant.name }}
         </VCardTitle>
-        <VAlert variant="flat" type="warning" class="mx-4 inline-block">
-          TODO: display the mean rating
-          <br>
-          Vuetify has a component for this. Use this one
-        </VAlert>
+
+        <!-- Mean rating -->
+        <div
+          v-if="rating"
+          class="mx-4 my-2 flex items-center gap-2 bg-black/50 rounded px-3 py-1 inline-flex"
+        >
+          <VRating
+            :model-value="rating.average.value"
+            half-increments
+            readonly
+            color="amber"
+            size="20"
+          />
+          <span class="text-white font-medium mt-2">
+            {{ rating.formatted }} ({{ rating.count }} avis)
+          </span>
+        </div>
       </VImg>
       <VCardText>
         <div class="grid grid-cols-2 gap-4">
           <RestaurantLocation :location="restaurant.location" />
           <KeyValue icon="mdi-phone">
             <p class="text-body-1">
-              {{ restaurant.phone }}
-              <VAlert type="warning">
-                ↑ TODO: we would like to display the formatted phone
-              </VAlert>
+              {{ restaurant.display_phone || restaurant.phone }}
             </p>
           </KeyValue>
         </div>
       </VCardText>
     </VCard>
+
     <aside>
-      <VAlert type="warning">
-        TODO: this should go under the company card on small device
-      </VAlert>
       <ul class="pa-0">
-        <RestaurantReview />
+        <RestaurantReview
+          v-for="review in restaurant.reviews"
+          :key="review.id"
+          :review="review"
+        />
       </ul>
     </aside>
   </div>


### PR DESCRIPTION
## Nouveautés

- Ajout de l’affichage de la **note moyenne** des restaurants (`VRating`) avec note + nombre d’avis.  
- Affichage du **numéro de téléphone formaté** (utilisation de la propriété `display_phone`).  
- Amélioration du **layout responsive** avec Tailwind CSS :  
  - 2 colonnes sur desktop (infos + aside).  
  - Repli automatique en une seule colonne sur mobile.  

## Détails techniques
- Intégration du composable `useRestaurantRating` pour calculer et afficher la note moyenne.  
- Utilisation de `VRating` en lecture seule avec style personnalisé.  
- Simplification du `grid layout`. 