### PR TITLE
test: add unit tests for RestaurantReview component

### DIFF
--- a/src/components/restaurant/__snapshots__/review.spec.ts.snap
+++ b/src/components/restaurant/__snapshots__/review.spec.ts.snap
@@ -1,0 +1,96 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`restaurant-review > renders a review 1`] = `
+"<li class=\\"v-card v-theme--light v-card--density-default v-card--variant-elevated va-company-review mb-5\\">
+  <!---->
+  <div class=\\"v-card__loader\\">
+    <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">
+      <!---->
+      <div class=\\"v-progress-linear__background\\" style=\\"opacity: NaN;\\"></div>
+      <div class=\\"v-progress-linear__buffer\\" style=\\"opacity: NaN; width: 0%;\\"></div>
+      <div class=\\"v-progress-linear__indeterminate\\">
+        <div class=\\"v-progress-linear__indeterminate long\\"></div>
+        <div class=\\"v-progress-linear__indeterminate short\\"></div>
+      </div>
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+  <div class=\\"v-card-text\\">
+    <!-- Rating -->
+    <div class=\\"v-rating v-rating--readonly v-theme--light mb-2\\"><label for=\\"v-rating-v-0-0\\" class=\\"v-rating__item--full\\"><span class=\\"v-rating__hidden\\">Rating 0 of 5</span>
+        <!---->
+      </label><input class=\\"v-rating__hidden\\" name=\\"v-rating-v-0\\" id=\\"v-rating-v-0-0\\" type=\\"radio\\" tabindex=\\"-1\\" readonly=\\"\\" value=\\"0\\">
+      <div class=\\"v-rating__wrapper\\">
+        <!---->
+        <div class=\\"v-rating__item\\"><label for=\\"v-rating-v-0-0-5\\" class=\\"v-rating__item--half\\"><span class=\\"v-rating__hidden\\">Rating 0.5 of 5</span><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light text-amber v-btn--density-default v-btn--variant-plain\\" style=\\"width: 20px; height: 20px;\\" aria-label=\\"Rating 0.5 of 5\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+              <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-star mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+              <!---->
+              <!---->
+            </button></label><input class=\\"v-rating__hidden\\" name=\\"v-rating-v-0\\" id=\\"v-rating-v-0-0-5\\" type=\\"radio\\" tabindex=\\"-1\\" readonly=\\"\\" value=\\"0.5\\"><label for=\\"v-rating-v-0-1\\" class=\\"v-rating__item--full\\"><span class=\\"v-rating__hidden\\">Rating 1 of 5</span><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light text-amber v-btn--density-default v-btn--variant-plain\\" style=\\"width: 20px; height: 20px;\\" aria-label=\\"Rating 1 of 5\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+              <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-star mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+              <!---->
+              <!---->
+            </button></label><input class=\\"v-rating__hidden\\" name=\\"v-rating-v-0\\" id=\\"v-rating-v-0-1\\" type=\\"radio\\" tabindex=\\"-1\\" readonly=\\"\\" value=\\"1\\"></div>
+        <!---->
+      </div>
+      <div class=\\"v-rating__wrapper\\">
+        <!---->
+        <div class=\\"v-rating__item\\"><label for=\\"v-rating-v-0-1-5\\" class=\\"v-rating__item--half\\"><span class=\\"v-rating__hidden\\">Rating 1.5 of 5</span><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light text-amber v-btn--density-default v-btn--variant-plain\\" style=\\"width: 20px; height: 20px;\\" aria-label=\\"Rating 1.5 of 5\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+              <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-star mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+              <!---->
+              <!---->
+            </button></label><input class=\\"v-rating__hidden\\" name=\\"v-rating-v-0\\" id=\\"v-rating-v-0-1-5\\" type=\\"radio\\" tabindex=\\"-1\\" readonly=\\"\\" value=\\"1.5\\"><label for=\\"v-rating-v-0-2\\" class=\\"v-rating__item--full\\"><span class=\\"v-rating__hidden\\">Rating 2 of 5</span><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light text-amber v-btn--density-default v-btn--variant-plain\\" style=\\"width: 20px; height: 20px;\\" aria-label=\\"Rating 2 of 5\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+              <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-star mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+              <!---->
+              <!---->
+            </button></label><input class=\\"v-rating__hidden\\" name=\\"v-rating-v-0\\" id=\\"v-rating-v-0-2\\" type=\\"radio\\" tabindex=\\"-1\\" readonly=\\"\\" value=\\"2\\"></div>
+        <!---->
+      </div>
+      <div class=\\"v-rating__wrapper\\">
+        <!---->
+        <div class=\\"v-rating__item\\"><label for=\\"v-rating-v-0-2-5\\" class=\\"v-rating__item--half\\"><span class=\\"v-rating__hidden\\">Rating 2.5 of 5</span><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light text-amber v-btn--density-default v-btn--variant-plain\\" style=\\"width: 20px; height: 20px;\\" aria-label=\\"Rating 2.5 of 5\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+              <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-star mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+              <!---->
+              <!---->
+            </button></label><input class=\\"v-rating__hidden\\" name=\\"v-rating-v-0\\" id=\\"v-rating-v-0-2-5\\" type=\\"radio\\" tabindex=\\"-1\\" readonly=\\"\\" value=\\"2.5\\"><label for=\\"v-rating-v-0-3\\" class=\\"v-rating__item--full\\"><span class=\\"v-rating__hidden\\">Rating 3 of 5</span><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light text-amber v-btn--density-default v-btn--variant-plain\\" style=\\"width: 20px; height: 20px;\\" aria-label=\\"Rating 3 of 5\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+              <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-star mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+              <!---->
+              <!---->
+            </button></label><input class=\\"v-rating__hidden\\" name=\\"v-rating-v-0\\" id=\\"v-rating-v-0-3\\" type=\\"radio\\" tabindex=\\"-1\\" readonly=\\"\\" value=\\"3\\"></div>
+        <!---->
+      </div>
+      <div class=\\"v-rating__wrapper\\">
+        <!---->
+        <div class=\\"v-rating__item\\"><label for=\\"v-rating-v-0-3-5\\" class=\\"v-rating__item--half\\"><span class=\\"v-rating__hidden\\">Rating 3.5 of 5</span><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light text-amber v-btn--density-default v-btn--variant-plain\\" style=\\"width: 20px; height: 20px;\\" aria-label=\\"Rating 3.5 of 5\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+              <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-star mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+              <!---->
+              <!---->
+            </button></label><input class=\\"v-rating__hidden\\" name=\\"v-rating-v-0\\" id=\\"v-rating-v-0-3-5\\" type=\\"radio\\" tabindex=\\"-1\\" readonly=\\"\\" value=\\"3.5\\"><label for=\\"v-rating-v-0-4\\" class=\\"v-rating__item--full\\"><span class=\\"v-rating__hidden\\">Rating 4 of 5</span><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light text-amber v-btn--density-default v-btn--variant-plain\\" style=\\"width: 20px; height: 20px;\\" aria-label=\\"Rating 4 of 5\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+              <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-star mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+              <!---->
+              <!---->
+            </button></label><input class=\\"v-rating__hidden\\" name=\\"v-rating-v-0\\" id=\\"v-rating-v-0-4\\" type=\\"radio\\" checked=\\"\\" tabindex=\\"-1\\" readonly=\\"\\" value=\\"4\\"></div>
+        <!---->
+      </div>
+      <div class=\\"v-rating__wrapper\\">
+        <!---->
+        <div class=\\"v-rating__item\\"><label for=\\"v-rating-v-0-4-5\\" class=\\"v-rating__item--half\\"><span class=\\"v-rating__hidden\\">Rating 4.5 of 5</span><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light text-amber v-btn--density-default v-btn--variant-plain\\" style=\\"width: 20px; height: 20px;\\" aria-label=\\"Rating 4.5 of 5\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+              <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-star-outline mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+              <!---->
+              <!---->
+            </button></label><input class=\\"v-rating__hidden\\" name=\\"v-rating-v-0\\" id=\\"v-rating-v-0-4-5\\" type=\\"radio\\" tabindex=\\"-1\\" readonly=\\"\\" value=\\"4.5\\"><label for=\\"v-rating-v-0-5\\" class=\\"v-rating__item--full\\"><span class=\\"v-rating__hidden\\">Rating 5 of 5</span><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light text-amber v-btn--density-default v-btn--variant-plain\\" style=\\"width: 20px; height: 20px;\\" aria-label=\\"Rating 5 of 5\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+              <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-star-outline mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+              <!---->
+              <!---->
+            </button></label><input class=\\"v-rating__hidden\\" name=\\"v-rating-v-0\\" id=\\"v-rating-v-0-5\\" type=\\"radio\\" tabindex=\\"-1\\" readonly=\\"\\" value=\\"5\\"></div>
+        <!---->
+      </div>
+    </div><!-- Review text -->
+    <p class=\\"text-gray-700 whitespace-pre-line\\">I've had decent lunches at Billy The Butcher a couple of times now. It's what I would describe as a trendy burger joint on the 4th floor of the Alsterhaus...</p>
+  </div>
+  <!---->
+  <!----><span class=\\"v-card__underlay\\"></span>
+</li>"
+`;

--- a/src/components/restaurant/review.spec.ts
+++ b/src/components/restaurant/review.spec.ts
@@ -1,9 +1,18 @@
-// import { mount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
+import RestaurantReview from './review.vue';
+import restaurantsResponse from '@/mock/restaurants.json';
 
-// import RestaurantReview from './review.vue';
+const review = restaurantsResponse[0].reviews[0];
 
 describe(`restaurant-review`, () => {
-  test.todo(`no props`);
+  test(`no props should throw an error`, () => {
+    expect(() => mount(RestaurantReview)).toThrowError();
+  });
 
-  it.todo(`renders a review`);
+  it(`renders a review`, () => {
+    const wrapper = mount(RestaurantReview, {
+      props: { review },
+    });
+    expect(wrapper.html()).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Description

Ajout des tests unitaires pour le composant **RestaurantReview**.

- Vérifie que le composant lance une erreur si aucune prop `review` n’est fournie.
- Vérifie que l’affichage d’un avis est correct (rating + texte).
- Ajout de snapshots pour garantir la stabilité du rendu.

## Détails des changements

- Nouveau fichier `src/components/restaurant/review.spec.ts`.

## Résultats

- Tous les tests unitaires passent (`pnpm test:all`).
- Couverture améliorée sur l’affichage des avis clients.
